### PR TITLE
Fix header color syntax on schedule page

### DIFF
--- a/Schedule/index.md
+++ b/Schedule/index.md
@@ -4,7 +4,7 @@
 <style>
     .header-row {
         background-color: #0d3350;
-        color: #ffffff;https://github.com/icsob2024/icsob2024.github.io/edit/main/Schedule/index.md
+        color: #ffffff;
         font-weight: bold;
         text-align: center;
     }


### PR DESCRIPTION
## Summary
- remove stray URL from `.header-row` color definition on schedule page

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68933d7f0bec8322b6d9b5ffca7946b7